### PR TITLE
Quote declarations with global_declaration instead of program -> program

### DIFF
--- a/src/reify.ml4
+++ b/src/reify.ml4
@@ -611,6 +611,10 @@ struct
     let (fn,_) = quote_term_remember (fun _ () -> ()) (fun _ () -> ()) in
     fst (fn () env trm)
 
+  let quote_mind_decl env trm =
+    let (_,fn) = quote_term_remember (fun _ () -> ()) (fun _ () -> ()) in
+    fst (fn () env trm)
+
   type defType =
     Ind of Names.inductive
   | Const of Names.kernel_name

--- a/src/reify.mli
+++ b/src/reify.mli
@@ -60,6 +60,7 @@ module type Quoter = sig
 end
 
 module Reify(Q : Quoter) : sig
+  val quote_mind_decl : Environ.env -> Names.mutual_inductive -> Q.quoted_decl
   val quote_term : Environ.env -> Constr.t -> Q.t
   val quote_term_rec : Environ.env -> Constr.t -> Q.quoted_program
 end

--- a/src/template_coq.ml4
+++ b/src/template_coq.ml4
@@ -25,7 +25,7 @@ struct
   type quoted_cast_kind = cast_kind
   type quoted_kernel_name = char list
   type quoted_inductive = inductive
-  type quoted_decl = program -> program
+  type quoted_decl = global_decl
   type quoted_program = program
   type quoted_int = Datatypes.nat
   type quoted_proj = projection
@@ -128,11 +128,16 @@ struct
             ind_type = t;
             ind_kelim = kelim;
             ind_ctors = ctors; ind_projs = p }) r in
-    fun pr ->
-    PType (kn,p,r,pr)
-  let mkConstant kn ty body = fun pr -> PConstr (kn,ty,body,pr)
-  let mkAxiom kn t = fun pr -> PAxiom (kn,t,pr)
-  let mkExt e p = e p
+    InductiveDecl (kn, {ind_npars = p; ind_bodies = r})
+
+  let mkConstant kn ty body =
+    ConstantDecl (kn, { cst_name = kn; cst_type = ty; cst_body = Some body })
+
+  let mkAxiom kn ty =
+    ConstantDecl (kn, { cst_name = kn; cst_type = ty; cst_body = None })
+
+  let mkExt d p = extend_program p d
+
   let mkIn c = PIn c
 end
 

--- a/theories/Ast.v
+++ b/theories/Ast.v
@@ -107,3 +107,27 @@ Record mutual_inductive_entry : Set := {
 (*  mind_entry_universes : Univ.universe_context; *)
   mind_entry_private : option bool
 }.
+
+
+Record constant_decl :=
+  { cst_name : ident;
+    cst_type : term;
+    cst_body : option term }.
+
+Record minductive_decl :=
+  { ind_npars : nat;
+    ind_bodies : list inductive_body }.
+
+Inductive global_decl :=
+| ConstantDecl : ident -> constant_decl -> global_decl
+| InductiveDecl : ident -> minductive_decl -> global_decl.
+
+Definition extend_program (p : program) (d : global_decl) : program :=
+  match d with
+  | ConstantDecl i {| cst_name:=_;  cst_type:=ty;  cst_body:=Some body |}
+    => PConstr i ty body p
+  | ConstantDecl i {| cst_name:=_;  cst_type:=ty;  cst_body:=None |}
+    => PAxiom i ty p
+  | InductiveDecl i {| ind_npars:=n; ind_bodies := l |}
+    => PType i n l p
+  end.

--- a/theories/Typing.v
+++ b/theories/Typing.v
@@ -63,18 +63,6 @@ Definition succ_sort s :=
 
 (** Typing derivations *)
 
-Record constant_decl :=
-  { cst_name : ident;
-    cst_type : term;
-    cst_body : option term }.
-
-Record minductive_decl :=
-  { ind_npars : nat;
-    ind_bodies : list inductive_body }.
-
-Inductive global_decl :=
-| ConstantDecl : ident -> constant_decl -> global_decl
-| InductiveDecl : ident -> minductive_decl -> global_decl.
 
 Definition global_decl_ident d :=
   match d with


### PR DESCRIPTION
Is it useful for you? It was for me...
I moved some definitions from Typing to Ast to avoid loading a new file in template_coq.ml4.